### PR TITLE
Use minification-friendly code wherever required

### DIFF
--- a/ng-bs-animated-button.js
+++ b/ng-bs-animated-button.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('jp.ng-bs-animated-button', []).
-  directive('jpNgBsAnimatedButton', function($timeout) {
+  directive('jpNgBsAnimatedButton', [ '$timeout', function($timeout) {
     return {
       restrict: 'AE',
       replace: true,
@@ -10,7 +10,7 @@ angular.module('jp.ng-bs-animated-button', []).
         result: '=',
         options: '=?'
       },
-      controller: function($scope) {
+      controller: [ '$scope', function($scope) {
         $scope.options = $scope.options || {};
         $scope.options = {
           buttonDefaultClass: $scope.options.buttonDefaultClass || 'btn-primary',
@@ -29,7 +29,7 @@ angular.module('jp.ng-bs-animated-button', []).
           animationCompleteTime: $scope.options.animationCompleteTime || '2000',
           iconsPosition: $scope.options.iconsPosition || 'left'
         };
-      },
+      }],
       template:
         '<button type="submit" class="btn {{buttonClass}} {{buttonSize}} btn-ng-bs-animated clearfix" ng-disabled="{{formIsInvalid}}">' +
           '<div class="icons pull-{{iconsPosition}}">' +
@@ -104,4 +104,5 @@ angular.module('jp.ng-bs-animated-button', []).
           }, true).bind(this);
       }
     };
-  });
+  }]
+);


### PR DESCRIPTION
- When the following code is minified, it will replace all the
  variables with shorter files:

``` javascript
    /* Unminified */

    function($scope) {
        console.log($scope);
    }

    /* After minification */

    function(a) {
        console.log(a);
    }
```
- In this example, the $scope part should not be removed, but it is.
  To avoid it, AngularJS provides a way. Instead of having just a
  function, the function should be a second element of an array; the
  first element should be the argument of the function and that should
  be a string. The correct way would be:

``` javascript
    [ '$scope', function($scope) {
        console.log($scope);
    }]
```
- This should be done only for objects that should be referred by
  name. Like providers ($routeParams, $scope, $attrs etc.), factories
  and services (MyFactory etc.). So, a link function does not need
  this style of code whereas a controller function, does.
  
  Check under the 'A Note on Minification' at
  https://docs.angularjs.org/tutorial/step_05
